### PR TITLE
Resolve SID S-1-5-19 to localized name to set proper NTFS ACL…

### DIFF
--- a/Framework/SubCall/Global/BISF.psm1
+++ b/Framework/SubCall/Global/BISF.psm1
@@ -3719,7 +3719,9 @@ function Set-ACLrights {
 
 	$acl = Get-Acl -Path $path
 	#$perm = "local service", "FullControl", "ContainerInherit, ObjectInherit", "None", "Allow"
-	$perm = "S-1-5-19", "FullControl", "ContainerInherit, ObjectInherit", "None", "Allow"
+	$localServiceSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-19")
+	$localServiceName = ($localServiceSID.Translate( [System.Security.Principal.NTAccount])).Value
+	$perm = $localServiceName, "FullControl", "ContainerInherit, ObjectInherit", "None", "Allow"
 	$rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $perm
 	try {
 		$acl.SetAccessRule($rule)
@@ -3727,6 +3729,7 @@ function Set-ACLrights {
 	catch {
 		Write-BISFlog -Msg "Error during set NTFS rights. The error is: $_" -Type W -SubMsg
 	}
+
 
 
 	$acl | Set-Acl -Path $path


### PR DESCRIPTION
… even on non-english machines.

**Summary**

This PR fixes/implements the following **bugs/features**
Resolves proper localized name for "Local Service" to set proper NTFS ACL in Set-ACLrights.

**Closing issues**
Fixes #172 
