### PR TITLE
Resolve Multiple Certificate Issue with EnableSSLVDA.ps1

### DIFF
--- a/Framework/SubCall/Personalization/05_PersBISF_EnableSSLVDA.ps1
+++ b/Framework/SubCall/Personalization/05_PersBISF_EnableSSLVDA.ps1
@@ -173,9 +173,10 @@ Process {
 
         #If no certificate thumbprint has been specified, check for any valid certificate within Local Machine Certificate Store (Subject Alternative Name > Computername).
         else{
-            $Cert = $Store.Certificates | where { $_.DnsNameList.Unicode -like "$($env:COMPUTERNAME)*" } | sort NotAfter -Descending | Select -First 1
+            $Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like "$($env:COMPUTERNAME)*") } | sort NotAfter -Descending | Select -First 1
 			if (!$Cert){
-				$Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like ("*." + "$([System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain().Name)"))} | sort NotAfter -Descending | Select -First 1
+				$WildcardDNSName = "*." + [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain().Name
+				$Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like $WildcardDNSName) } | sort NotAfter -Descending | Select -First 1
 			}
 			$CertificateThumbPrint = $Cert.GetCertHashString()
 

--- a/Framework/SubCall/Personalization/05_PersBISF_EnableSSLVDA.ps1
+++ b/Framework/SubCall/Personalization/05_PersBISF_EnableSSLVDA.ps1
@@ -173,10 +173,10 @@ Process {
 
         #If no certificate thumbprint has been specified, check for any valid certificate within Local Machine Certificate Store (Subject Alternative Name > Computername).
         else{
-            $Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like "$($env:COMPUTERNAME)*") } | sort NotAfter -Descending | Select -First 1
+            $Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like "$($env:COMPUTERNAME)*") -and ($_.EnhancedKeyUsageList -like "*Server Authentication*") } | sort NotAfter -Descending | Select -First 1
 			if (!$Cert){
 				$WildcardDNSName = "*." + [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain().Name
-				$Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like $WildcardDNSName) } | sort NotAfter -Descending | Select -First 1
+				$Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like $WildcardDNSName) -and ($_.EnhancedKeyUsageList -like "*Server Authentication*") } | sort NotAfter -Descending | Select -First 1
 			}
 			$CertificateThumbPrint = $Cert.GetCertHashString()
 


### PR DESCRIPTION
**Summary**
Force EnableSSLVDA.ps1 to only use certificates with Server Authentication usage.
Citrix VDA will only be able to use a certificate if it has this usage tag.

This PR fixes/implements the following **bugs/features**
* [ ] Bug #340 

Does the code pass AppVeyor?
* [ ] Yes

**Closing issues**

Closes #340 
