### PR TITLE
Fixes RES One AM agent from not being registered

### DIFF
--- a/Framework/SubCall/Preparation/10_PrepBISF_RES.ps1
+++ b/Framework/SubCall/Preparation/10_PrepBISF_RES.ps1
@@ -155,7 +155,7 @@ Process {
 			$TestROAValue = Test-BISFRegistryValue -Path "$HKLM_REG_ROA\Agent" -Value "DispatcherListKGC"
 			IF ($TestROAValue) { Remove-ItemProperty -Path "$HKLM_REG_ROA\Agent" -Name "DispatcherListKGC" }
 
-			Set-ItemProperty -Path "$HKLM_REG_ROA\Agent" -Name "Prepared4Image" -Value "$computer"
+			Set-ItemProperty -Path "$HKLM_REG_ROA\Agent" -Name "Prepared4Image" -Value "BISFStaging"
 
 			$TestROAValue = Test-BISFRegistryValue -Path "$HKLM_REG_ROA\Preferences" -Value "WUID"
 			IF ($TestROAValue) { Remove-ItemProperty -Path "$HKLM_REG_ROA\Preferences" -Name "WUID" }


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

**Summary**

This PR fixes/implements the following **bugs/features**

* [x] Bug Fixes: RES One AM agent from not being registered

The BIS-F script is using the hostname of the VM to fill in the Prepare4Image registry key, this causes the RES One AM agent not being registered in the console. This means you cannot use the same VM with the same hostname afterwards in combination with the RES One AM agent.
Source: https://forums.ivanti.com/s/article/The-RES-ONE-Automation-agent-doesn-t-register-in-the-Console-after-using-Prepare-for-image?language=en_US

@EUCweb is it possible to add this change?
