### PR TITLE
Update 10_PrepBISF_AV-WinDefend.ps1

### DIFF
--- a/Framework/SubCall/Preparation/10_PrepBISF_AV-WinDefend.ps1
+++ b/Framework/SubCall/Preparation/10_PrepBISF_AV-WinDefend.ps1
@@ -62,7 +62,7 @@ Process {
 			Write-BISFLog -Msg "Updating virus signatures... please wait"
 			Start-Process -FilePath "$ProductPath\MpCMDrun.exe" -ArgumentList "-SignatureUpdate" -WindowStyle Hidden
 			$procID = (Get-Process -Name "MpCMDrun" | ? { $_.SI -eq (Get-Process -PID $PID).SessionId }).Id # get MPCmdRun for the current user only
-			Show-BISFProgressBar -$CheckProcessId $procID -ActivityText "$Product is updating the virus signatures...please wait"
+			Show-BISFProgressBar -CheckProcessId $procID -ActivityText "$Product is updating the virus signatures...please wait"
 
 			IF ($LIC_BISF_CLI_AV_VIE_CusScanArgsb -eq 1) {
 				Write-BISFLog -Msg "Enable Custom Scan Arguments"


### PR DESCRIPTION
Remove erroneous $ sign from Show-BISFProgressBar invocation.



Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug: #284


<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The erroneous $ sign is causing the underlying Show-BISFProgressBar to not be able to check the state of the invoked, current user Windows Defender AV process. Removing it ensures that when the AV scan invoked under the current user finishes, it will actually move on to the rest of the preparation tasks.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #284 
