### PR TITLE
Change Process status handling for MpCmdRun based off Proc ID

### DIFF
--- a/Framework/SubCall/Preparation/10_PrepBISF_AV-WinDefend.ps1
+++ b/Framework/SubCall/Preparation/10_PrepBISF_AV-WinDefend.ps1
@@ -73,8 +73,9 @@ Process {
 			}
 
 			Write-BISFLog -Msg "Running Scan with arguments: $args"
-			Start-Process -FilePath "$ProductPath\MpCMDrun.exe" -ArgumentList $args -WindowStyle Hidden
-			Show-BISFProgressBar -CheckProcess "MpCMDrun" -ActivityText "$Product is scanning the system...please wait"
+			#Gather process info for the MpCmdRun process so we can pass the correct ID to Show-BISFProgressBar
+			$MpCmdRunProc = Start-Process -FilePath "$ProductPath\MpCMDrun.exe" -ArgumentList $args -WindowStyle Hidden -PassThru
+			Show-BISFProgressBar -CheckProcessId $MpCmdRunProc.Id -ActivityText "$Product is scanning the system...please wait"
 		}
 		Else {
 			Write-BISFLog -Msg "No Scan will be performed"


### PR DESCRIPTION
Changing the way Show-BISFProgressBar handles processes by specifying process ID instead of just process name.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [X] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?
Ensures that when this script runs, it is only looking for the self initiated process instead of any MpCmdRun processes that might exist. 
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
