### PR TITLE
Fixes "Method invocation failed because [Microsoft.Management.Infrast…

### DIFF
--- a/Framework/SubCall/Preparation/51_PrepBISF_DeleteRDSGracePeriod.ps1
+++ b/Framework/SubCall/Preparation/51_PrepBISF_DeleteRDSGracePeriod.ps1
@@ -112,6 +112,10 @@ Process {
 
 		#Take Ownership of Registry Key
 		$key = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey("SYSTEM\CurrentControlSet\Control\Terminal Server\RCM\GracePeriod", [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::takeownership)
+		if($null -eq $key) {
+			Write-BISFLog "Registry key SYSTEM\CurrentControlSet\Control\Terminal Server\RCM\GracePeriod was not yet created. It will be created as soon as a user logs on. Reset will not be required."
+			return
+		}
 		$acl = $key.GetAccessControl([System.Security.AccessControl.AccessControlSections]::None)
 		$SID = "S-1-5-32-544" #Builtin\Admnistrators
 		$objSID = New-Object System.Security.Principal.SecurityIdentifier($SID)

--- a/Framework/SubCall/Preparation/80_PrepBISF_WriteCacheDisk.ps1
+++ b/Framework/SubCall/Preparation/80_PrepBISF_WriteCacheDisk.ps1
@@ -85,7 +85,7 @@ Begin {
 		18.01.2021 MS: HF 302 using function Get-BISFDiskID instead of the same code here
 
 		#>
-		Get-BISFDiskID -Driveletter $PVSDiskDrive
+		Get-BISFDiskID -Driveletter $PVSDiskDrive -ThrowWhenNotFound $False
 		Write-BISFLog -Msg "Set uniqueID $getid for volume $VolNbr / Driveletter $PVSDiskDrive to Registry $hklm_software_LIC_CTX_BISF_SCRIPTS"
 		Set-ItemProperty -Path $hklm_software_LIC_CTX_BISF_SCRIPTS -Name $reg_value_UniqueID -value $DiskID -ErrorAction SilentlyContinue
 	}

--- a/Framework/SubCall/Preparation/97_PrepBISF_PRE_BaseImage.ps1
+++ b/Framework/SubCall/Preparation/97_PrepBISF_PRE_BaseImage.ps1
@@ -944,14 +944,10 @@ Begin {
 		$SysDrive = $env:SystemDrive
 		$Sysdrvlabel = Get-CimInstance -ClassName Win32_Volume -Filter "Driveletter = '$SysDrive' " | % { $_.Label }
 		$DriveLabel = "OSDisk"
-		IF ($Sysdrvlabel -eq $null) {
+		IF ($null -eq $Sysdrvlabel) {
 			Write-BISFLog -Msg "DriveLabel for $SysDrive would be set to $DriveLabel" -ShowConsole -Color Cyan
-			$drive = Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = '$SysDrive'"
-			$drive.Label = "$DriveLabel"
-			$drive.put() | Ou-Null
+			Get-Volume | Where-Object {$_.DriveLetter -eq $SysDrive.Substring(0,1)} | Set-Volume -NewFileSystemLabel "$DriveLabel"   
 		}
-
-
 	}
 
 

--- a/Framework/SubCall/Preparation/98_PrepBISF_BUILD_BaseImage.ps1
+++ b/Framework/SubCall/Preparation/98_PrepBISF_BUILD_BaseImage.ps1
@@ -350,14 +350,11 @@ Process {
 			ELSE {
 				Write-BISFLog -Msg "Skipping Citrix Personal vDisk Inventory"
 			}
-			ELSE {
-				Write-BISFLog -Msg "Citrix Personal vDisk could be run on Client-OS (ProductType=1) only"
-			}
-
 		}
-		ELSE {
-			Write-BISFLog -Msg "Skip personal vDisk Inventory Update, Citrix Virtual Desktop Agent is not installed"
+		ELSE { #Not sure what this else belongs to, maybe a leftover?
+			Write-BISFLog -Msg "Citrix Personal vDisk could be run on Client-OS (ProductType=1) only"
 		}
+		
 
 		IF ($runPvd -eq "true") {
 			$CheckPvdLog = Test-BISFLog -CheckLogFile "$Pvd_LOGFile" -SearchString "$Pvd_LOGFile_search"
@@ -423,6 +420,9 @@ Process {
 		ELSE {
 			Write-BISFLog -Msg "Skip convert System to vDisk, Citrix Provisioning Services Software not installed"
 		}
+	}
+	ELSE {
+		Write-BISFLog -Msg "Skip personal vDisk Inventory Update, Citrix Virtual Desktop Agent is not installed"
 	}
 }
 


### PR DESCRIPTION
Fixes "Method invocation failed because [Microsoft.Management.Infrastructure.CimInstance] does not contain a method named 'put'" error by using standard powershell cmdlets  'Get-Volume' and 'Set-Volume'


This PR fixes/implements the following **bugs/features**

* [*] 365

<!-- Make sure tests pass on AppVeyor before submitting. -->

Fixes #365 
