### PR TITLE
Update 05_PersBISF_EnableSSLVDA.ps1

### DIFF
--- a/Framework/SubCall/Personalization/05_PersBISF_EnableSSLVDA.ps1
+++ b/Framework/SubCall/Personalization/05_PersBISF_EnableSSLVDA.ps1
@@ -173,7 +173,7 @@ Process {
 
         #If no certificate thumbprint has been specified, check for any valid certificate within Local Machine Certificate Store (Subject Alternative Name > Computername).
         else{
-            $Cert = $Store.Certificates | where { $_.DnsNameList.Unicode -like "$($env:COMPUTERNAME)*" } | sort NotAfter -Descending | Select -First 1
+            $Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like "$($env:COMPUTERNAME)*") -and ($_.Issuer -notlike "CN=MS-Organization-P2P-Access*") } | sort NotAfter -Descending | Select -First 1
 			if (!$Cert){
 				$Cert = $Store.Certificates | where { ($_.DnsNameList.Unicode -like ("*." + "$([System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain().Name)"))} | sort NotAfter -Descending | Select -First 1
 			}


### PR DESCRIPTION
Filtered out certificate created by Azure AD Hybrid join

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

**Summary**

This PR fixes/implements the following **bugs/features**

When a VDA is Hybrid joined, but also using an SSL certificate, the script incorrectly selects the Hybrid join "CN=MS-Organization-P2P-Access" certificate. The pull request filters this certificate out of the returned objects.